### PR TITLE
Allow to use config.js from code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/.idea/

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ ghoma.onHeartbeat = function(plug) {
 ghoma.startServer(4196);
 ```
 
+Usage example to configure a plug to a custom server (or restore defaults) from code
+```js
+config.configure(gHomaPlugAddress, controlServer, controlPort, function (err) {
+    console.log(err ? 'Error: ' + err : 'Success');
+} /*, console.log to enabled debug log*/);
+
+
+//Restore default config of the plug
+config.restore(gHomaPlugAddress, function (err) {
+    console.log(err ? 'Error: ' + err : 'Success');
+}, console.log);
+```
 
 A more comprehensive example shows the node-ghoma library in combination with the express framework. See [express_example.js](https://github.com/rodney42/node-ghoma/blob/master/express_example.js) in the git repository.
 

--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 /**
- * Utitility programm to change the control server of a G-Homa plug.
+ * Utility programm to change the control server of a G-Homa plug.
  *
  * Usage:
  * node config.js <ghoma plug address> <control server address> <control server port>
@@ -14,36 +14,98 @@ var helloMessage = new Buffer("HF-A11ASSISTHREAD");
 var gHomaAddress = process.argv[2];
 var controlServer = process.argv[3];
 var controlPort = process.argv[4];
-var initDone=false;
+var initDone = false;
+var messagesReceive = [];
+var configHandler = function () {
+};
+var log = function () {
+
+};
 
 var client = dgram.createSocket("udp4");
 
-send(helloMessage);
-
 function send(message) {
-  console.log('SEND      : '+ message);
-  client.send(message, 0, message.length, 48899, gHomaAddress);
+    log('SEND      : ' + message);
+    client.send(message, 0, message.length, 48899, gHomaAddress);
+}
+
+function close() {
+    log('CLOSING');
+    messagesReceive = [];
+    initDone = false;
+    gHomaAddress = undefined;
+    controlPort = undefined;
+    controlServer = undefined;
+    client.close();
 }
 
 client.on('listening', function () {
-  var address = client.address();
-  console.log('LISTENING : ' + address.address + ":" + address.port);
+    var address = client.address();
+    log('LISTENING : ' + address.address + ":" + address.port);
+});
+
+client.on('error', function (err) {
+    log('ERROR     : ' + err);
+    close();
+    configHandler(err);
 });
 
 client.on('message', function (message, remote) {
-  console.log('RECEIVE   : '+ message);
-  if( !initDone ) {
-    initDone =true;
-    send(new Buffer("+ok"));        // Reply to first received data
-    //send(new Buffer("AT+H\r"));   // Uncomment to see the help page
-    send(new Buffer("AT+VER\r"));   // Request the version
-    send(new Buffer("AT+NETP=TCP,Client,"+controlPort+","+controlServer+"\r"));   // Send new network parameter
-    send(new Buffer("AT+NETP\r"));  // See the new settings
-
-    // Wait a while for replies and close
-    setTimeout(function() {
-      console.log('CLOSING');
-      client.close();
-    },1000*10)
-  }
+    log('RECEIVE   : ' + message);
+    if (initDone) {
+        messagesReceive.push(new String(message).trim());
+        if (messagesReceive.length === 3 && messagesReceive[0] !== '+ERR=-1' || messagesReceive.length === 4) {
+            const mess = messagesReceive[messagesReceive.length - 1];
+            const parts = messagesReceive[messagesReceive.length - 1].split(',');
+            if (parts[parts.length - 1] === controlServer && parts[parts.length - 2] === controlPort + '') {
+                log('Finish success : ' + mess);
+                configHandler(null);
+            }
+            else {
+                log('Finish error : ' + mess);
+                configHandler(mess);
+            }
+            close();
+        }
+    } else {
+        initDone = true;
+        send(new Buffer("+ok"));        // Reply to first received data
+        //send(new Buffer("AT+H\r"));   // Uncomment to see the help page
+        send(new Buffer("AT+VER\r"));   // Request the version
+        send(new Buffer("AT+NETP=TCP,Client," + controlPort + "," + controlServer + "\r"));   // Send new network parameter
+        send(new Buffer("AT+NETP\r"));  // See the new settings
+    }
 });
+
+if (gHomaAddress && controlServer && controlPort) {
+    log = console.log;
+    send(helloMessage);
+}
+
+module.exports = {
+    configure: function (plugAddress, newHost, port, handler, logger) {
+        gHomaAddress = plugAddress;
+        controlServer = newHost;
+        controlPort = port;
+        if (handler) {
+            configHandler = handler;
+        }
+        if (logger) {
+            log = logger;
+        }
+        send(helloMessage);
+    },
+    restore: function (plugAddress, handler, logger) {
+        log = logger;
+        gHomaAddress = plugAddress;
+        controlServer = 'plug.g-homa.com';
+        controlPort = 4196;
+        if (handler) {
+            configHandler = handler;
+        }
+        if (logger) {
+            log = logger;
+        }
+        send(helloMessage);
+    }
+}

--- a/config_example.js
+++ b/config_example.js
@@ -1,0 +1,15 @@
+var config = require('./config');
+var gHomaAddress = 'gHomaIPAddress'; // IP address of g-homa plug
+var controlServer = 'customServerAddress'; // Your server address
+var controlPort = 4196;
+
+config.configure(gHomaAddress, controlServer, controlPort, function (err) {
+    console.log(err ? 'Error: ' + err : 'Success');
+} /*, console.log */);
+
+/*
+ //Restore default config of the plug
+ config.restore(gHomaAddress, function (err) {
+ console.log(err ? 'Error: ' + err : 'Success');
+ }, console.log);
+ */


### PR DESCRIPTION
Hi again, 

With this we can now use config.js file from command line or by code, so no retro compatibility issue. 

I do no if you prefer it this way separated or what we can do is to add a `configurePlug` and `restorePlug` method into `ghoma.js` that use config.js to have unified api.

Let me know what do you think.