### PR TITLE
Switch state only for valid values

### DIFF
--- a/ghoma.js
+++ b/ghoma.js
@@ -110,8 +110,10 @@ var server = net.createServer(function(socket) {
             newstate = 'on'
           } else if( msg.payload[msg.payload.length-1] == 0x00 ) {
             newstate = 'off'
+          } else {
+            log('HANDLE', 'STATUS', 'Status unknown: ' +  msg.payload[msg.payload.length-1]);
           }
-          if( newstate!=ghoma.state ) {
+          if( newstate!=ghoma.state && newstate != 'unknown') {
             ghoma.prevstate = ghoma.state;
             ghoma.state = newstate;
             ghoma.statechanged = new Date();


### PR DESCRIPTION
I often see other status update messages, which seem to be unrelated to the on/off state switch. In the current implementation they change the switch state to "unknown", which is not correct.

This PR fixes that.

Sidenote: where can I find the documentation this command status? Is it part of the heartbeat?
http://www.sabreadv.com/wp-content/uploads/HF-LPC100-User-Manual-V1.0.pdf